### PR TITLE
TDSLoader : Jump over unknown ChunkType 0x3338

### DIFF
--- a/examples/js/loaders/TDSLoader.js
+++ b/examples/js/loaders/TDSLoader.js
@@ -205,6 +205,12 @@
 
 			while ( next !== 0 ) {
 
+				if (next === 0x3338 ) {
+
+					var subChunk = this.readChunk( data );
+					next = this.nextChunk( data, subChunk );
+				}
+				
 				if ( next === N_TRI_OBJECT ) {
 
 					this.resetPosition( data );


### PR DESCRIPTION
Jump over unknown ChunkType 0x3338

Related issue: #XXXX

**Description**

I have a .3ds file can not be loaded with threeJs. That file encapsulate the N_TRI_OBJECT chunk in a unknown 0x3338 chunk.
This pull request ignores the 0x3338 chunk type

[3ds-example-not-working.zip](https://github.com/tomsoftware/three.js/files/7265741/fortec_a1_st.zip)